### PR TITLE
Remove unused import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 from distutils.core import setup
-import os
-import numpy
 
 setup(name="kmeans_radec", 
       url="https://github.com/esheldon/kmeans_radec",
@@ -10,4 +8,3 @@ setup(name="kmeans_radec",
       author_email="erin.sheldon@gmail.com",
       install_requires=['numpy'],
       version="0.1")
-


### PR DESCRIPTION
This PR removes unused import in `setup.py`. In particular, `import numpy` would prevent this package from installation if `numpy` is not already installed since the setup script would only see `install_requires` after all the imports. 

cf. https://github.com/LSSTDESC/descqa/pull/102/checks?check_run_id=1483450361#step:6:28